### PR TITLE
Timeout value to transport open_channel call.

### DIFF
--- a/paramiko_jump/client.py
+++ b/paramiko_jump/client.py
@@ -134,6 +134,7 @@ class SSHJumpClient(SSHClient):
                 kind='direct-tcpip',
                 dest_addr=(hostname, port),
                 src_addr=transport.getpeername(),
+                timeout=timeout,
             )
 
         return super().connect(


### PR DESCRIPTION
Passing in timeout value into open_channel calls allows you to override default timeout option for Paramiko just as you would expect initial connection call to jumphosts. Can pass in shorter default timeout values to deal with jumphosts that are down, etc.